### PR TITLE
Add note about expanding on string_measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ups battery.charge=100,battery.charge.low=10,battery.charge.warning=20,battery.m
 
 ## Usage
 
-Edit the script `cmd` variable to reflect your setup. Specifically, change 'ups' to whatever you named your UPS in `NUT` or `upsd`.
+Edit the script `cmd` variable to reflect your setup. Specifically, change 'ups' to whatever you named your UPS in `NUT` or `upsd`.  ALSO, add the measurement names that contain string values to the string_measurements array (in sorted order!) so they will be properly quoted for influxdb.
 
 Call the script from `telegraf.conf` like this
 ```


### PR DESCRIPTION
Trying to get this set up for my MGE Pulsar 2200 UPS and ran into some strings not getting quoted, then noticed in the code where it was deciding what to quote and what not to..  seeing this note in advance would have saved me a few minutes! :)  Also realized they need to be sorted.